### PR TITLE
Adding documentation link to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ![](https://ksr-ugc.imgix.net/assets/004/795/589/5f86f0b07d25ed77630ab07bb22034fe_original.png?v=1446143010&w=680&fit=max&auto=format&lossless=true&s=d1e343beaff1c4d757695532089e3f33)
 
-Simple IDE for developing Tingbot apps on the Mac. Download from the [releases page](http://github.com/tingbot/tide/releases/).
+Simple IDE for developing Tingbot apps on the Mac. Download from the [releases page](http://github.com/tingbot/tide/releases/). Python API documentation at [tingbot-python.readthedocs.org](http://tingbot-python.readthedocs.org/).
 
 [Back us on Kickstarter](https://www.kickstarter.com/projects/744235676/647977615)!


### PR DESCRIPTION
I found the Python API documentation link at one point (later remembered it was on the Kickstarter page) but after hunting on tingbot.com and the Tide GitHub I wasn't able to find it. Added a quick link to the readme for it.
